### PR TITLE
Remove in window check when updating mouse focus

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -243,14 +243,6 @@ SDL_UpdateMouseFocus(SDL_Window * window, int x, int y, Uint32 buttonstate, SDL_
     SDL_Mouse *mouse = SDL_GetMouse();
     SDL_bool inWindow = SDL_TRUE;
 
-    if (window && ((window->flags & SDL_WINDOW_MOUSE_CAPTURE) == 0)) {
-        int w, h;
-        SDL_GetWindowSize(window, &w, &h);
-        if (x < 0 || y < 0 || x >= w || y >= h) {
-            inWindow = SDL_FALSE;
-        }
-    }
-
 /* Linux doesn't give you mouse events outside your window unless you grab
    the pointer.
 

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -243,6 +243,17 @@ SDL_UpdateMouseFocus(SDL_Window * window, int x, int y, Uint32 buttonstate, SDL_
     SDL_Mouse *mouse = SDL_GetMouse();
     SDL_bool inWindow = SDL_TRUE;
 
+    /* This was causing an issue when sdl creates 2 surfaces, the wrong window was set as the mouse focus which would block mouse input
+    For further context : https://github.com/MinoGames/sdl/pull/2 https://app.asana.com/0/970371062922148/1184728371528635/f  */
+
+   /*  if (window && ((window->flags & SDL_WINDOW_MOUSE_CAPTURE) == 0)) {
+        int w, h;
+        SDL_GetWindowSize(window, &w, &h);
+        if (x < 0 || y < 0 || x >= w || y >= h) {
+            inWindow = SDL_FALSE;
+        }
+    } */ 
+
 /* Linux doesn't give you mouse events outside your window unless you grab
    the pointer.
 


### PR DESCRIPTION
# Context

Issue can be broken down as follows:

1. SDL creates 2 surfaces a smaller one eg 1080x1720 and one the correct resolution of the the device eg 1080x1920. It will first create the smaller surface, destroy it, then create the surface with the same window size as the device. When this is done correctly there are no ill effects as SDL_UpdateMouseFocus gets called on the surface with the correct resolution.

2. In this specific case it causes an issue when we go to the help page and switch back quickly to the landing scene. In this case the smaller surface hasn't had a chance to be destroyed causing SDL_UpdateMouseFocus to be called on the smaller surface.

2. This causes a problem because it is possible that mouse.y is greater than the size of the smaller surface due to the size of the device. When this happens SDL_SetMouseFocus(NULL) is called.

3. With no focus object SDL_SendTouch gets blocked and we are not able to send to SDL_MOUSEBUTTONDOWN events causing the game to become unresponsive to touch events.

4. To remedy this issue we remove the check in SDL_UpdateMouseFocus that sets inWindow = SDL_FALSE, because for our application we should always only have 1 fullscreen window it is safe to make the assumption that inWindow = SDL_TRUE.

https://app.asana.com/0/970371062922148/1184728371528635/f

# Changes

Commented out block of code check that handles the setting of inWindow to false.