### PR TITLE
clear openGL queue before app minimized

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4076,14 +4076,14 @@ void SDL_OnApplicationWillResignActive(void)
             SDL_SendWindowEvent(window, SDL_WINDOWEVENT_MINIMIZED, 0, 0);
         }
     }
-    glFinish();
     SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
+    glFinish();
 }
 
 void SDL_OnApplicationDidEnterBackground(void)
 {
-    glFinish();
     SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
+    glFinish();
 }
 
 void SDL_OnApplicationWillEnterForeground(void)

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -280,7 +280,7 @@ SDL_CreateWindowTexture(SDL_VideoDevice *unused, SDL_Window * window, Uint32 * f
                 }
             }
         }
-        
+
         if (!renderer) {
             for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
                 SDL_RendererInfo info;
@@ -1220,7 +1220,7 @@ SDL_UpdateFullscreenMode(SDL_Window * window, SDL_bool fullscreen)
     if (SDL_strcmp(_this->name, "cocoa") == 0) {  /* don't do this for X11, etc */
         if (window->is_destroying && (window->last_fullscreen_flags & FULLSCREEN_MASK) == SDL_WINDOW_FULLSCREEN_DESKTOP)
             return 0;
-    
+
         /* If we're switching between a fullscreen Space and "normal" fullscreen, we need to get back to normal first. */
         if (fullscreen && ((window->last_fullscreen_flags & FULLSCREEN_MASK) == SDL_WINDOW_FULLSCREEN_DESKTOP) && ((window->flags & FULLSCREEN_MASK) == SDL_WINDOW_FULLSCREEN)) {
             if (!Cocoa_SetWindowFullscreenSpace(window, SDL_FALSE)) {
@@ -1933,7 +1933,7 @@ SDL_GetWindowPosition(SDL_Window * window, int *x, int *y)
     /* Fullscreen windows are always at their display's origin */
     if (window->flags & SDL_WINDOW_FULLSCREEN) {
         int displayIndex;
-        
+
         if (x) {
             *x = 0;
         }
@@ -2296,7 +2296,7 @@ SDL_SetWindowFullscreen(SDL_Window * window, Uint32 flags)
     if (SDL_UpdateFullscreenMode(window, FULLSCREEN_VISIBLE(window)) == 0) {
         return 0;
     }
-    
+
     window->flags &= ~FULLSCREEN_MASK;
     window->flags |= oldflags;
     return -1;
@@ -2441,11 +2441,11 @@ SDL_SetWindowModalFor(SDL_Window * modal_window, SDL_Window * parent_window)
     if (!_this->SetWindowModalFor) {
         return SDL_Unsupported();
     }
-    
+
     return _this->SetWindowModalFor(_this, modal_window, parent_window);
 }
 
-int 
+int
 SDL_SetWindowInputFocus(SDL_Window * window)
 {
     CHECK_WINDOW_MAGIC(window, -1);
@@ -2453,7 +2453,7 @@ SDL_SetWindowInputFocus(SDL_Window * window)
     if (!_this->SetWindowInputFocus) {
         return SDL_Unsupported();
     }
-    
+
     return _this->SetWindowInputFocus(_this, window);
 }
 
@@ -3057,7 +3057,7 @@ SDL_GL_ExtensionSupported(const char *extension)
 
 /* Deduce supported ES profile versions from the supported
    ARB_ES*_compatibility extensions. There is no direct query.
-   
+
    This is normally only called when the OpenGL driver supports
    {GLX,WGL}_EXT_create_context_es2_profile.
  */
@@ -4077,11 +4077,13 @@ void SDL_OnApplicationWillResignActive(void)
         }
     }
     SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
+    glFinish();
 }
 
 void SDL_OnApplicationDidEnterBackground(void)
 {
     SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
+    glFinish();
 }
 
 void SDL_OnApplicationWillEnterForeground(void)

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4076,14 +4076,14 @@ void SDL_OnApplicationWillResignActive(void)
             SDL_SendWindowEvent(window, SDL_WINDOWEVENT_MINIMIZED, 0, 0);
         }
     }
-    SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
     glFinish();
+    SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
 }
 
 void SDL_OnApplicationDidEnterBackground(void)
 {
-    SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
     glFinish();
+    SDL_SendAppEvent(SDL_APP_DIDENTERBACKGROUND);
 }
 
 void SDL_OnApplicationWillEnterForeground(void)


### PR DESCRIPTION
# Context

Attempts to solve the crash when the app is put into the background
https://console.firebase.google.com/u/2/project/cat-game-d21eb/crashlytics/app/ios:com.minogames.cats.beta/issues/7d97d9a1dac498f1cfd64db32593dc37?time=last-seven-days&sessionEventKey=38117285bc7145bc9e1b4cec957dca26_1516858587661764989

We are not allowed to issue draw calls when the app is minimized so we need to empty the openGL command buffer before sending the app to the background

https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/ImplementingaMultitasking-awareOpenGLESApplication/ImplementingaMultitasking-awareOpenGLESApplication.html#//apple_ref/doc/uid/TP40008793-CH5-SW1

# Changes

- issue the glFinish command before and when the app is sent to the background
https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glFinish.xml

# Test Cases

For iOS only
- Minimize the game while playing. The app should not crash
- Try minimizing while performing different actions such as: while idle, loading a scene, watching a cat animation, watching an ad, scrolling the tower, playing a minigame, etc