### PR TITLE
Fixed bug 4299 - A recent change requires Core Bluetooth framework on iOS

### DIFF
--- a/include/SDL_config_iphoneos.h
+++ b/include/SDL_config_iphoneos.h
@@ -138,7 +138,7 @@
 
 /* Enable MFi joystick support */
 #define SDL_JOYSTICK_MFI 1
-#define SDL_JOYSTICK_HIDAPI 1
+/*#define SDL_JOYSTICK_HIDAPI 1*/
 
 #ifdef __TVOS__
 #define SDL_SENSOR_DUMMY    1


### PR DESCRIPTION
# Context
A good description of the problem here:
https://bugzilla.libsdl.org/show_bug.cgi?id=4299

https://hg.libsdl.org/SDL/rev/bd445097c0e5

# Changes

- Cherry-picked commit from https://github.com/native-toolkit/sdl/commit/e572215f5a3bb042ec035f67521c27c6448ad861

# Test Cases
- After rebuilding lime and linking latest changes to Collector, the game should not crash on launch for iOS

Signed-off-by: Jason Brennan <jason@minogames.com>